### PR TITLE
Update org.junit.jupiter:junit-jupiter to 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.14.4</version>
+            <version>6.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Update org.junit.jupiter:junit-jupiter from 5.14.4 to 6.1.1

## Context
This dependency upgrade was split from Renovate PR #47 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected