### PR TITLE
Upgrade minimum Java version from 11 to 17

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         java-version:
-          - '11'
           - '17'
           - '21'
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <configuration>
-                                    <source>17</source>
+                                    <source>${maven.compiler.source}</source>
                                     <doclint>none</doclint>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.apitomy</groupId>
     <artifactId>apitomy-maven-plugin</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 
@@ -54,8 +54,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -193,7 +193,7 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <configuration>
-                                    <source>11</source>
+                                    <source>17</source>
                                     <doclint>none</doclint>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
## Summary
- Bump `maven.compiler.source` and `maven.compiler.target` from 11 to 17
- Update javadoc `<source>` in the release profile from 11 to 17
- Remove Java 11 from the CI verification matrix (keep 17 and 21)
- Bump project version to 1.1.0-SNAPSHOT

## Test plan
- [ ] Build passes on Java 17
- [ ] Build passes on Java 21
- [ ] All 46 tests pass